### PR TITLE
Update 06-data-subsetting.md

### DIFF
--- a/_episodes/06-data-subsetting.md
+++ b/_episodes/06-data-subsetting.md
@@ -1427,7 +1427,7 @@ be changed with the third argument, `drop = FALSE`).
 > >
 > >    
 > >    ~~~
-> >    # gapminder[gapminder$lifeExp > 80]
+> >    # gapminder[gapminder$lifeExp > 80,]
 > >    gapminder[gapminder$lifeExp > 80,]
 > >    ~~~
 > >    {: .language-r}


### PR DESCRIPTION
Episode: Subsetting Data; Challange 7 #3 
  gapminder[gapminder$lifeExp >80] should read gapminder[gapminder$lifeExp >80, ]  - comma after the 80

